### PR TITLE
Fixing Youtube link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Installing Tools
 - PDF : https://github.com/in28minutes/SpringIn28Minutes/blob/master/InstallationGuide-JavaEclipseAndMaven_v2.pdf
-- Video : https://www.youtube.com/watch?v=DLPjCZ5n_SM
+- Video : https://www.youtube.com/watch?v=eqRF4xHoGck
 
 ## Course Overview
 ### Step List


### PR DESCRIPTION
Updated the correct youtube link for the video tutorial. The earlier link was pointing to installing Java and maven